### PR TITLE
fix: userdel spurious ubuntu user stealing uid 1000

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM eclipse-temurin:21-jre
 
-RUN useradd -ms /bin/bash powsybl
+RUN userdel -r ubuntu && useradd -ms /bin/bash powsybl
 USER powsybl
 WORKDIR /home/powsybl
 RUN mkdir .itools


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
<!-- please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes -->
- [x] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**Does this PR already have an issue describing the problem?**
<!-- If so, link to this issue using `'Fixes #XXX'` and skip the rest -->
no


**What kind of change does this PR introduce?**
<!-- Bug fix, feature, docs update, ... -->
Bug fix

**Does this PR introduce a new Powsybl Action implying to be implemented in simulators or pypowsybl?**
- [ ] Yes, the corresponding issue is [here](link)
- [x] No

**What is the current behavior?**
<!-- You can also link to an open issue here -->
files in /home/powsybl are ignored


**What is the new behavior (if this is a feature change)?**
files are not ignored


**Does this PR introduce a breaking change or deprecate an API?**
- [ ] Yes
- [x] No


**Other information**:
<!-- if any of the questions/checkboxes don't apply, please delete them entirely -->
in the new java21 images, there is an existing user with uuid1000
We run our images with the uid 1000 and place our config files in /home/powysbl, expecting that it is readable by user 1000
When an existing user exsist, our powsybl user is created with uid 1001 and so the user with uid 1001 can't read /home/powsybl 